### PR TITLE
Sketches november 2015

### DIFF
--- a/clj/melos/src/melos/lib/chord_seq.clj
+++ b/clj/melos/src/melos/lib/chord_seq.clj
@@ -350,7 +350,8 @@
   [diss-fn-params events]
   (-> (handle-dissonance diss-fn-params)
       (reductions events)
-      (rest)))
+      ))
+      ;; (rest)))
 
 ;;-----------------------------------------------------------------------------
 ;; Modify durations.

--- a/clj/melos/src/melos/lib/note.clj
+++ b/clj/melos/src/melos/lib/note.clj
@@ -7,6 +7,7 @@
    :group (gensym "G__")
    :merge-left? false
    :merge-right? false
+   :dissonance-contributor? true
    :part nil,
    :count 0,
    :is-rest? false

--- a/clj/melos/src/melos/lib/schemas.clj
+++ b/clj/melos/src/melos/lib/schemas.clj
@@ -13,6 +13,7 @@
               :merge-right? s/Bool
               :group s/Any
               :is-rest? s/Bool
+              :dissonance-contributor? s/Bool
               :part PartName
               :max-count s/Int
               :count s/Int))

--- a/clj/melos/src/melos/score/compose_score.clj
+++ b/clj/melos/src/melos/score/compose_score.clj
@@ -37,7 +37,7 @@
   [events]
   (let [lst (last events)]
     (if (>= (chord/scaled-dissonance-value (map :pitch lst))
-            (chord/scaled-dissonance-value [0 2 4 5]))
+            (chord/scaled-dissonance-value [0 1 2]))
       7/4
       1/4)))
 
@@ -46,8 +46,8 @@
   (let [head (stepwise-mod/maybe-split-vertical-moment
               (first event-seq))
         event-seq-mod (concat head (rest event-seq))
-        last-event-dur (get-last-event-duration event-seq-mod)]
-    (->> event-seq-mod
+        last-event-dur (get-last-event-duration event-seq)]
+    (->> event-seq
          ;; hardcoded
          (rhythm-tree/extend-last last-event-dur)
          (rhythm-tree/make-r-tree measures)
@@ -75,8 +75,8 @@
   (let [states (map #(assoc initial-state-fn :events %)
                     (make-chord-seqs chord-seqs))]
 
-  (->> (map compose-event-seq (progressbar (into [] states)))
-       (post-process))))
+    (->> (map compose-event-seq (progressbar (into [] states)))
+         (post-process))))
 
 (defn write-session
   [output-dir session]

--- a/clj/melos/src/melos/score/compose_score.clj
+++ b/clj/melos/src/melos/score/compose_score.clj
@@ -115,7 +115,7 @@
                             [:upper :lower :ped])
                    x))
             (combinations/weave-seqs indexed-segments)
-            (repeat [measures/measure-3]))))
+            (repeat [measures/measure-4]))))
 
 ;; Phrases, start- and end-points: the end of a phrase is usually connected to the start of the next one -- intervals between phrases matter.
 

--- a/clj/melos/src/melos/score/group_c.clj
+++ b/clj/melos/src/melos/score/group_c.clj
@@ -30,14 +30,11 @@
             {:pitch (->>
                      (range 13)
                      (map (fn [x] [x]))
-                     ;; [[0] [0 1] [0 2] [0 2 3] [0 2 4] [2 4] [4] [4 5] [4 6] [4 6 7] [4 6 8] [6 8] [8]]
-                     ;; [[-3] [-3 -1] [-3 -1 0] [-1 0] [-1 0 2] [0 2] [2] [2 3] [2 3 5] [2 5]]
                      (transpose-all transposition))
              :part [part-name]
              :fn utils/make-chord-from-pitch-vector-params
              :partition (partial utils/cyclic-partition [1 2 1 2 3])
              :merge-left? [false]
-             ;; :dissonance-contributor? [false true false false true true]
              ;; :dissonance-contributor? [false false true]
              :duration dur
              :merge-right? [false]
@@ -59,12 +56,8 @@
                               drop-n
                               dur]}]
             {:pitch (->>
-                     ;; (range 13)
-                     ;; [4 2 -3 4 2 -3 7 9 7 4 2 5 5 5 5 5 5 5 5]
-                     ;; [[-3] [-3 -1] [-3 -1 0] [-1 0] [-1 0 2] [0 2] [2] [2 3] [2 3 5] [2 5]]
                      (range 7)
                      (map (fn [x] [x]))
-                         ;; [[-6] [-6 -4] [-6 -4 -2] [-2]]
                      (transpose-all transposition))
              :part [part-name]
              :fn utils/make-chord-from-pitch-vector-params
@@ -86,8 +79,7 @@
                               transposition
                               drop-n
                               dur]}]
-            {:pitch (->>
-                     [[0] [0 2] [2] [2 3] [3]]
+            {:pitch (->> [[0] [0 2] [2] [2 3] [3]]
                          (transpose-all transposition))
              :part [part-name]
              :fn utils/make-chord-from-pitch-vector-params
@@ -95,20 +87,7 @@
              :drop-n drop-n
              :duration dur})]
     (->> {:part-name [:ped]
-          :pitches [
-                    [
-                     [0] [0 -2]
-                     [-2] [-2 0]
-                     [0] [0 2]
-                     [2] [2 0]
-                     ]
-                    [
-                     [0] [0 -2]
-                     [-2] [-2 -3]
-                     [-3] [-2 -3]
-                     [-2] [-2 0]
-                     ]
-                    ]
+          :pitches [:not-used]
           :transposition [-20]
           :drop-n (range 2)
           :dur [[1/4]]}
@@ -119,14 +98,8 @@
   {:upper (upper)
    :lower (lower)
    :ped (ped)
-   :melodic-indices [
-                     ;; max number of events:
-                     (take 9 (cycle [:upper :lower :ped]))
-                     (take 6 (cycle [:upper :lower :ped]))
-                     (take 13 (cycle [:upper :lower :ped]))
-                     ;; (take 30 (cycle [:upper :lower :ped :lower :ped]))
-                     ;; (take 20 (cycle [:upper :lower :ped :lower :ped :lower :ped :lower]))
-                     ]})
+   :melodic-indices [(take 18 (cycle [:upper :lower :ped]))
+                     (take 13 (cycle [:upper :lower :ped]))]})
 
 (def partition-events-fn
   (partial score-utils/part-count-sufficient? 3))
@@ -138,9 +111,8 @@
 
 (def diss-params
   {:check (fn [events]
-            (let [asdf (chord/dissonance-contributors events)]
             (<= (chord/scaled-dissonance-value (map :pitch events))
-                (chord/scaled-dissonance-value [0 1 2]))))})
+                (chord/scaled-dissonance-value [0 1 2])))})
 
 (def initial-state
   {:diss-fn-params {:max-count 100
@@ -148,7 +120,7 @@
                     ;; TODO: pass on diss-value
                     :diss-params diss-params}
    :tempo 200
-   ;; :measures is not used -- it is hardcoded in compose-score/compose
+   ;; TODO: measures is not used -- it is hardcoded in compose-score/compose
    :measures [measures/measure-3]
    :pre []
    :post []
@@ -165,43 +137,17 @@
                          durations)]
     (/ (apply + dissonances) (count pitch-sets))))
 
-(defn get-max-dissonance
-  [phrase]
-  (let [pitch-sets (map #(map :pitch %) phrase)
-        durations (map chord/get-melodic-duration phrase)
-        dissonances (map (fn [ps dur]
-                           (* (chord/scaled-dissonance-value ps)
-                              dur))
-                         pitch-sets
-                         durations)]
-    (apply max dissonances)))
-
 (defn post-process
   [events]
-  (letfn [(filterfn [x]
-            (->> x
-                 ;; (partition-by partition-events-fn)
-                 ;; (take 8)
-                 ;; (conj [])
-                 ;; (filter filter-events-fn)
-                 ;; (take 1)
-                 (take 8)
-                 ;; (conj [])
-                 ;; (filter filter-events-fn)
-                 ))]
   (->> events
-       ;; (map filterfn)
-       ;; (take 8)
        (utils/distinct-by score-utils/pitch-profile)
-       ;; (sort-by (fn [x] (:count x)))
-       ;; (reverse)
-       ;; (take 30)
+       (sort-by get-average-dissonance)
+       (take 30)
        (partition 1)
-       (assoc {} :segments))))
+       (assoc {} :segments)))
 
 (def session-config
   {:persist-to "testing-c.edn"
    :params {:chord-seqs materials
             :initial-state-fn initial-state
-            :post-process post-process
-            }})
+            :post-process post-process}})

--- a/clj/melos/src/melos/score/group_c.clj
+++ b/clj/melos/src/melos/score/group_c.clj
@@ -27,13 +27,15 @@
                               transposition
                               dur
                               drop-n]}]
-            {:pitch (->> (concat (range -3 21) [20])
-                         (map (fn [x] [2 x]))
+            {:pitch (->> 
+                         [[0] [0 1] [0 2]]
                          (transpose-all transposition))
              :part [part-name]
              :fn utils/make-chord-from-pitch-vector-params
-             :partition (partial utils/cyclic-partition [2 3 1])
+             :partition (partial utils/cyclic-partition [3])
              :merge-left? [false]
+             ;; :dissonance-contributor? [false true false false true true]
+             :dissonance-contributor? [false false true]
              :duration (concat (repeat 8 1/4) [3/4] [3/4])
              :merge-right? [false]
              :drop-n drop-n})]
@@ -53,17 +55,17 @@
                               drop-n
                               dur]}]
             {:pitch (->> (range 8)
-                         (map (fn [x] [4 x]))
+                         (map (fn [x] [x]))
                          (transpose-all transposition))
              :part [part-name]
              :fn utils/make-chord-from-pitch-vector-params
-             :partition (partial utils/cyclic-partition [3 1 1])
+             :partition (partial utils/cyclic-partition [1 1 1])
              :drop-n drop-n
              :duration dur})]
     (->> {:part-name [:lower]
           :pitches [[0 2 4 5 7 9 10 3 1 6 5]]
-          :transposition [-5]
-          :drop-n (range 3)
+          :transposition [-5 -4 -3 -2]
+          :drop-n (range 7)
           :dur [[1/4]]}
          (unfold-parameters)
          (map (comp utils/unfold-events blueprint)))))
@@ -120,13 +122,14 @@
 
 (defn filter-events-fn
   [events]
-  (and (>= (count events) 6)
+  (and (>= (count events) 3)
        (every? (partial score-utils/part-count-sufficient? 3) events)))
 
 (def diss-params
   {:check (fn [events]
-            (<= (chord/scaled-dissonance-value (map :pitch events))
-                (chord/scaled-dissonance-value [0 1 2])))})
+            (let [asdf (chord/dissonance-contributors events)]
+            (<= (chord/scaled-dissonance-value (map :pitch asdf))
+                (chord/scaled-dissonance-value [0 2 4 5]))))})
 
 (def initial-state
   {:diss-fn-params {:max-count 100

--- a/clj/melos/src/melos/score/group_c.clj
+++ b/clj/melos/src/melos/score/group_c.clj
@@ -136,6 +136,18 @@
                          durations)]
     (/ (apply + dissonances) (count pitch-sets))))
 
+;; (defn get-average-pitch
+;;   [phrase]
+;;   (let [pitches (mapcat #(map :pitch %) phrase)]
+;;     (/ (apply + pitches) (count pitches))))
+
+(defn get-max-dissonance
+  [phrase]
+  (let [pitch-sets (map #(map :pitch %) phrase)
+        durations (map chord/get-melodic-duration phrase)
+        dissonances (map chord/scaled-dissonance-value pitch-sets)]
+    (apply max dissonances)))
+
 (defn post-process
   [events]
   (->> events
@@ -150,3 +162,4 @@
    :params {:chord-seqs materials
             :initial-state-fn initial-state
             :post-process post-process}})
+

--- a/clj/melos/src/melos/score/group_c.clj
+++ b/clj/melos/src/melos/score/group_c.clj
@@ -28,14 +28,14 @@
                               dur
                               drop-n]}]
             {:pitch (->>
-                     ;; (range 13)
-                     ;; (map (fn [x] [x]))
+                     (range 13)
+                     (map (fn [x] [x]))
                      ;; [[0] [0 1] [0 2] [0 2 3] [0 2 4] [2 4] [4] [4 5] [4 6] [4 6 7] [4 6 8] [6 8] [8]]
-                     [[-3] [-3 -1] [-3 -1 0] [-1 0] [-1 0 2] [0 2] [2] [2 3] [2 3 5] [2 5]]
+                     ;; [[-3] [-3 -1] [-3 -1 0] [-1 0] [-1 0 2] [0 2] [2] [2 3] [2 3 5] [2 5]]
                      (transpose-all transposition))
              :part [part-name]
              :fn utils/make-chord-from-pitch-vector-params
-             :partition (partial utils/cyclic-partition [1])
+             :partition (partial utils/cyclic-partition [1 2 1 2 3])
              :merge-left? [false]
              ;; :dissonance-contributor? [false true false false true true]
              ;; :dissonance-contributor? [false false true]
@@ -45,7 +45,7 @@
     (->> {:part-name [:upper]
           :pitches [[0 2 4 5 7 -3 -2 3 1 6 5]]
           :transposition [0]
-          :drop-n (range 8)
+          :drop-n (range 5)
           :dur [[1/4]]}
          (unfold-parameters)
          (map (comp utils/unfold-events blueprint)))))
@@ -61,8 +61,9 @@
             {:pitch (->>
                      ;; (range 13)
                      ;; [4 2 -3 4 2 -3 7 9 7 4 2 5 5 5 5 5 5 5 5]
-                     [[-3] [-3 -1] [-3 -1 0] [-1 0] [-1 0 2] [0 2] [2] [2 3] [2 3 5] [2 5]]
-                     ;; (map (fn [x] [x]))
+                     ;; [[-3] [-3 -1] [-3 -1 0] [-1 0] [-1 0 2] [0 2] [2] [2 3] [2 3 5] [2 5]]
+                     (range 7)
+                     (map (fn [x] [x]))
                          ;; [[-6] [-6 -4] [-6 -4 -2] [-2]]
                      (transpose-all transposition))
              :part [part-name]
@@ -72,8 +73,8 @@
              :duration dur})]
     (->> {:part-name [:lower]
           :pitches [[0 2 4 5 7 9 10 3 1 6 5]]
-          :transposition (range -6 -3)
-          :drop-n (range 8)
+          :transposition [-4]
+          :drop-n [0 1 2 3 4]
           :dur [[1/4]]}
          (unfold-parameters)
          (map (comp utils/unfold-events blueprint)))))
@@ -85,7 +86,7 @@
                               transposition
                               drop-n
                               dur]}]
-            {:pitch (->> 
+            {:pitch (->>
                      [[0] [0 2] [2] [2 3] [3]]
                          (transpose-all transposition))
              :part [part-name]
@@ -108,8 +109,8 @@
                      [-2] [-2 0]
                      ]
                     ]
-          :transposition (range -18 -15)
-          :drop-n (range 5)
+          :transposition [-20]
+          :drop-n (range 2)
           :dur [[1/4]]}
          (unfold-parameters)
          (map (comp utils/unfold-events blueprint)))))
@@ -120,9 +121,11 @@
    :ped (ped)
    :melodic-indices [
                      ;; max number of events:
-                     (take 20 (cycle [:upper :lower :ped]))
+                     (take 9 (cycle [:upper :lower :ped]))
+                     (take 6 (cycle [:upper :lower :ped]))
+                     (take 13 (cycle [:upper :lower :ped]))
                      ;; (take 30 (cycle [:upper :lower :ped :lower :ped]))
-                     (take 20 (cycle [:upper :lower :ped :lower :ped :lower :ped :lower]))
+                     ;; (take 20 (cycle [:upper :lower :ped :lower :ped :lower :ped :lower]))
                      ]})
 
 (def partition-events-fn
@@ -137,7 +140,7 @@
   {:check (fn [events]
             (let [asdf (chord/dissonance-contributors events)]
             (<= (chord/scaled-dissonance-value (map :pitch events))
-                (chord/scaled-dissonance-value [0 2 4 5]))))})
+                (chord/scaled-dissonance-value [0 1 2]))))})
 
 (def initial-state
   {:diss-fn-params {:max-count 100
@@ -177,27 +180,28 @@
   [events]
   (letfn [(filterfn [x]
             (->> x
-                 (partition-by partition-events-fn)
-                 (filter filter-events-fn)
-                 (take 1)))]
+                 ;; (partition-by partition-events-fn)
+                 ;; (take 8)
+                 ;; (conj [])
+                 ;; (filter filter-events-fn)
+                 ;; (take 1)
+                 (take 8)
+                 ;; (conj [])
+                 ;; (filter filter-events-fn)
+                 ))]
   (->> events
-       (mapcat filterfn)
+       ;; (map filterfn)
+       ;; (take 8)
        (utils/distinct-by score-utils/pitch-profile)
-       (sort-by (fn [x] (:count x)))
-       (reverse)
-       (take 30)
+       ;; (sort-by (fn [x] (:count x)))
+       ;; (reverse)
+       ;; (take 30)
        (partition 1)
        (assoc {} :segments))))
 
 (def session-config
   {:persist-to "testing-c.edn"
-   :params {
-            :filter-fn (fn [x]
-                         (->> x
-                              (partition-by partition-events-fn)
-                              (filter filter-events-fn)
-                              (take 1)))
-            :chord-seqs materials
+   :params {:chord-seqs materials
             :initial-state-fn initial-state
             :post-process post-process
             }})

--- a/clj/melos/src/melos/score/group_c.clj
+++ b/clj/melos/src/melos/score/group_c.clj
@@ -41,12 +41,11 @@
              :drop-n drop-n})]
     (->> {:part-name [:upper]
           :pitches [[0 2 4 5 7 -3 -2 3 1 6 5]]
-          :transposition [0]
+          :transposition [0 12]
           :drop-n (range 5)
           :dur [[1/4]]}
          (unfold-parameters)
          (map (comp utils/unfold-events blueprint)))))
-
 
 (defn lower
   []
@@ -66,7 +65,7 @@
              :duration dur})]
     (->> {:part-name [:lower]
           :pitches [[0 2 4 5 7 9 10 3 1 6 5]]
-          :transposition [-4]
+          :transposition [-4 8]
           :drop-n [0 1 2 3 4]
           :dur [[1/4]]}
          (unfold-parameters)

--- a/clj/melos/src/melos/score/group_d.clj
+++ b/clj/melos/src/melos/score/group_d.clj
@@ -1,4 +1,4 @@
-(ns melos.score.group-c
+(ns melos.score.group-d
   (:require [clojure.math.combinatorics :as combinatorics]
             [melos.lib
              [note :refer [make-note]]
@@ -31,11 +31,12 @@
                      ;; (range 13)
                      ;; (map (fn [x] [x]))
                      ;; [[0] [0 1] [0 2] [0 2 3] [0 2 4] [2 4] [4] [4 5] [4 6] [4 6 7] [4 6 8] [6 8] [8]]
-                     [[-3] [-3 -1] [-3 -1 0] [-1 0] [-1 0 2] [0 2] [2] [2 3] [2 3 5] [2 5]]
+                     [2]
+                     (map (fn [x] [x]))
                      (transpose-all transposition))
              :part [part-name]
              :fn utils/make-chord-from-pitch-vector-params
-             :partition (partial utils/cyclic-partition [1])
+             :partition (partial utils/cyclic-partition [3 2 1 1 2 2 1 1])
              :merge-left? [false]
              ;; :dissonance-contributor? [false true false false true true]
              ;; :dissonance-contributor? [false false true]
@@ -45,7 +46,7 @@
     (->> {:part-name [:upper]
           :pitches [[0 2 4 5 7 -3 -2 3 1 6 5]]
           :transposition [0]
-          :drop-n (range 8)
+          :drop-n [0 4]
           :dur [[1/4]]}
          (unfold-parameters)
          (map (comp utils/unfold-events blueprint)))))
@@ -60,9 +61,8 @@
                               dur]}]
             {:pitch (->>
                      ;; (range 13)
-                     ;; [4 2 -3 4 2 -3 7 9 7 4 2 5 5 5 5 5 5 5 5]
-                     [[-3] [-3 -1] [-3 -1 0] [-1 0] [-1 0 2] [0 2] [2] [2 3] [2 3 5] [2 5]]
-                     ;; (map (fn [x] [x]))
+                     [4 2 5 5 5 5 5 5 5 5]
+                     (map (fn [x] [x]))
                          ;; [[-6] [-6 -4] [-6 -4 -2] [-2]]
                      (transpose-all transposition))
              :part [part-name]
@@ -72,7 +72,7 @@
              :duration dur})]
     (->> {:part-name [:lower]
           :pitches [[0 2 4 5 7 9 10 3 1 6 5]]
-          :transposition (range -6 -3)
+          :transposition [0]
           :drop-n (range 8)
           :dur [[1/4]]}
          (unfold-parameters)
@@ -85,8 +85,8 @@
                               transposition
                               drop-n
                               dur]}]
-            {:pitch (->> 
-                     [[0] [0 2] [2] [2 3] [3]]
+            {:pitch (->> [0 2 3 2 2]
+                         (map (fn [x] [x]))
                          (transpose-all transposition))
              :part [part-name]
              :fn utils/make-chord-from-pitch-vector-params
@@ -108,8 +108,8 @@
                      [-2] [-2 0]
                      ]
                     ]
-          :transposition (range -18 -15)
-          :drop-n (range 5)
+          :transposition [-15]
+          :drop-n (range 2)
           :dur [[1/4]]}
          (unfold-parameters)
          (map (comp utils/unfold-events blueprint)))))
@@ -130,7 +130,7 @@
 
 (defn filter-events-fn
   [events]
-  (and (>= (count events) 6)
+  (and (>= (count events) 8)
        (every? (partial score-utils/part-count-sufficient? 3) events)))
 
 (def diss-params
@@ -185,12 +185,11 @@
        (utils/distinct-by score-utils/pitch-profile)
        (sort-by (fn [x] (:count x)))
        (reverse)
-       (take 30)
        (partition 1)
        (assoc {} :segments))))
 
 (def session-config
-  {:persist-to "testing-c.edn"
+  {:persist-to "testing-d.edn"
    :params {
             :filter-fn (fn [x]
                          (->> x

--- a/clj/melos/src/melos/score/main.clj
+++ b/clj/melos/src/melos/score/main.clj
@@ -9,7 +9,7 @@
 (defn -main
   [output-path analysis-dir config-file-path]
   (let [{:keys [sessions composition-fn rerender-sessions? compose-score?]}
-         (eval (clojure.edn/read-string (slurp config-file-path)))]
+        ((comp eval clojure.edn/read-string slurp) config-file-path)]
     (when rerender-sessions?
       (doall (compose-score/calc-all-sessions analysis-dir sessions)))
     (when compose-score?


### PR DESCRIPTION
Simplify post-processing of events.
Avoid filtering based on dissonance-score (this always resulted in messy logic) -- instead, event-seqs can be *sorted* by this score.
